### PR TITLE
Mention supported network path, default values for optional fields and link to custom API source creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,7 +534,7 @@ enterprise_search.host_url: https://my-deployment.ent.europe-west1.gcp.cloud.es.
 
 Whether the connector should sync [document-level permissions (DLP)](#use-document-level-permissions-dlp) from network drives.
 
-By default, it is set to `Yes` i.e. by default, the connector will try to sync document-level permissions.
+By default, it is set to `Yes` i.e. the connector will try to sync document-level permissions.
 
 ```yaml
 enable_document_permission: Yes

--- a/README.md
+++ b/README.md
@@ -105,9 +105,10 @@ Each network drives connector syncs data from network drives into a Workplace Se
 
 Create a content source within Kibana:
 
-1. Navigate to **Enterprise Search** → **Workplace Search** → **Sources** → **Add Source** → **Custom Content Source**.
+1. Navigate to **Enterprise Search** → **Workplace Search** → **Sources** → **Add an organization content source** → **Custom API Source**.
 2. Name your Content Source, (e.g. Network Drives Connector).
-3. Choose **Configure network drives Connector**.
+
+For more details please refer [Elastic Documentation for creating a custom content source](https://www.elastic.co/guide/en/workplace-search/current/workplace-search-custom-api-sources.html#create-custom-source).
 
 Record the ID of the new content source. This value is labeled *Source Identifier* within Kibana. Later, you will [configure the connector](#configure-the-connector) with this value.
 
@@ -533,6 +534,8 @@ enterprise_search.host_url: https://my-deployment.ent.europe-west1.gcp.cloud.es.
 
 Whether the connector should sync [document-level permissions (DLP)](#use-document-level-permissions-dlp) from network drives.
 
+By default, it is set to `Yes` i.e. by default, the connector will try to sync document-level permissions.
+
 ```yaml
 enable_document_permission: Yes
 ```
@@ -561,6 +564,8 @@ Supports the following time format `YYYY-MM-DDTHH:MM:SSZ`
 start_time: 2022-04-01T04:44:16Z
 ```
 
+By default, it is set to unix epoch time `1970-01-01T00:00:00Z`
+
 #### `end_time`
 
 A UTC timestamp the connector uses to determine which objects to extract and sync from network drives. Determines the *stopping* point for a [full sync](#full-sync).
@@ -569,6 +574,8 @@ It supports the following time format YYYY-MM-DDTHH:MM:SSZ
 ```yaml
 end_time: 2022-04-01T04:44:16Z
 ```
+
+By default, it is set to current execution time.
 
 #### `log_level`
 
@@ -583,6 +590,8 @@ The level or severity that determines the threshold for [logging](#log-errors-an
 log_level: INFO
 ```
 
+By default, it is set to `INFO`.
+
 #### `retry_count`
 
 The number of retries to perform when there is a server error. The connector applies an exponential backoff algorithm to retries.
@@ -590,6 +599,8 @@ The number of retries to perform when there is a server error. The connector app
 ```yaml
 retry_count: 3
 ```
+
+By default, it is set to `3`.
 
 #### `network_drives_sync_thread_count`
 

--- a/README.md
+++ b/README.md
@@ -65,9 +65,7 @@ The steps above are relevant to all users. Some users may require additional fea
 Collect the information that is required to connect to your network drives:
 
 - The domain name where the network drive is present.
-- The network drives path the connector will crawl to fetch files. It should be the name of the folder shared via SMB followed by the path relative to that shared folder
-
-  (For Example: If `Users` is the name of SMB shared folder and folder to be fetched is `folder1`, then the path would be mentioned as `Users/folder1`)
+- The network drives path the connector will crawl to fetch files. This is the name of the folder shared via SMB, followed by the path relative to that shared folder. For example: if the name of the of SMB shared folder is `Users` and the folder to be fetched is `folder1`, then the path is `Users/folder1`.
 - The username the connector will use to log in to network drives.
 - The password the connector will use to log in to network drives.
 - The server IP address where the network drive is hosted.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ The steps above are relevant to all users. Some users may require additional fea
 Collect the information that is required to connect to your network drives:
 
 - The domain name where the network drive is present.
-- The network drives path the connector will crawl to fetch files.
+- The network drives path the connector will crawl to fetch files. It should be the name of the folder shared via SMB followed by the path relative to that shared folder
+
+  (For Example: If `Users` is the name of SMB shared folder and folder to be fetched is `folder1`, then the path would be mentioned as `Users/folder1`)
 - The username the connector will use to log in to network drives.
 - The password the connector will use to log in to network drives.
 - The server IP address where the network drive is hosted.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Collect the information that is required to connect to your network drives:
 
 Later, you will [configure the connector](#configure-the-connector) with these values.
 
+ℹ️ The connector uses [pysmb](https://pysmb.readthedocs.io/en/latest/) module for connecting to your Network Drives. pysmb supports SMB1 and SMB2.
+
 Some connector features require additional details. Review the following documentation if you plan to use these features:
 
 - [Customize extraction and syncing](#customize-extraction-and-syncing)

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Collect the information that is required to connect to your network drives:
 
 Later, you will [configure the connector](#configure-the-connector) with these values.
 
-ℹ️ The connector uses [pysmb](https://pysmb.readthedocs.io/en/latest/) module for connecting to your Network Drives. pysmb supports SMB1 and SMB2.
+ℹ️ The connector uses the [pysmb](https://pysmb.readthedocs.io/en/latest/) module to connect to your Network Drives. `pysmb` supports SMB1 and SMB2.
 
 Some connector features require additional details. Review the following documentation if you plan to use these features:
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Create a content source within Kibana:
 1. Navigate to **Enterprise Search** → **Workplace Search** → **Sources** → **Add an organization content source** → **Custom API Source**.
 2. Name your Content Source, (e.g. Network Drives Connector).
 
-For more details please refer [Elastic Documentation for creating a custom content source](https://www.elastic.co/guide/en/workplace-search/current/workplace-search-custom-api-sources.html#create-custom-source).
+For more details see [Elastic Documentation for creating a custom content source](https://www.elastic.co/guide/en/workplace-search/current/workplace-search-custom-api-sources.html#create-custom-source).
 
 Record the ID of the new content source. This value is labeled *Source Identifier* within Kibana. Later, you will [configure the connector](#configure-the-connector) with this value.
 


### PR DESCRIPTION
The goal of this PR is to address the following changes suggested in issue #15 :
- Mention the type of network path supported by the connector.
- Mention the default values taken by the connector for optional fields.
- Add a link to elastic documentation for creating a custom API source.